### PR TITLE
fix: reemplazar nombres reales por roles genéricos en actores de CUs

### DIFF
--- a/anexos/introduccion.md
+++ b/anexos/introduccion.md
@@ -56,7 +56,7 @@ Esta entrega inicial se enfoca en resolver la problemática crítica de la **ges
 
 ### 📌 1. Registrar Turno Médico
 
-**▫️Actor(es) involucrado(s):** Secretaria Valeria / Paciente.
+**▫️Actor(es) involucrado(s):** Secretaria / Paciente.
 
 **▫️Descripción breve:** Permite reservar un espacio de atención para un paciente con un profesional específico.
 
@@ -75,7 +75,7 @@ Esta entrega inicial se enfoca en resolver la problemática crítica de la **ges
 
 ### 📌 2. Reprogramar Turno Existente
 
-**▫️Actor(es) involucrado(s):** Secretaria Valeria.
+**▫️Actor(es) involucrado(s):** Secretaria.
 
 **▫️Descripción breve:** Cambia la fecha o el horario de una cita ya pactada a solicitud del médico o paciente.
 
@@ -94,7 +94,7 @@ Esta entrega inicial se enfoca en resolver la problemática crítica de la **ges
 
 ### 📌 3. Cancelar Turno
 
-**▫️Actor(es) involucrado(s):** Paciente / Secretaria Valeria.
+**▫️Actor(es) involucrado(s):** Paciente / Secretaria.
 
 **▫️Descripción breve:** Anula una reserva de turno liberando el espacio en la agenda médica.
 
@@ -113,7 +113,7 @@ Esta entrega inicial se enfoca en resolver la problemática crítica de la **ges
 
 ### 📌 4. Visualizar Agenda Médica (Día/Semana)
 
-**▫️Actor(es) involucrado(s):**  Médico (Dr. Molina) / Secretaria Valeria.
+**▫️Actor(es) involucrado(s):**  Médico / Secretaria.
 
 **▫️Descripción breve:** Permite consultar la distribución de citas y espacios libres en diferentes vistas temporales.
 
@@ -132,7 +132,7 @@ Esta entrega inicial se enfoca en resolver la problemática crítica de la **ges
 
 ### 📌 5. Administrar Disponibilidad del Profesional
 
-**▫️Actor(es) involucrado(s):** Médico / Secretaria Valeria.
+**▫️Actor(es) involucrado(s):** Médico / Secretaria.
 
 **▫️Descripción breve:** Define los días y rangos horarios en los que el médico atiende, estableciendo la base para evitar conflictos.
 

--- a/changelog.md
+++ b/changelog.md
@@ -46,11 +46,6 @@
 *   **Coordinador:** 
     *   Estructura de repositorio y revisiones con IA. [Issue #12] [PR #23]
 
-### Fixed
-- Corregida sintaxis de enlace de NotebookLM grupal en introduccion.md. 
-  PR: https://github.com/Purezaamor/SistemaTurnosMedicos/pull/30 - (Modelador de Casos de Uso)
----
-
 
 release/entrega-final-correcta
 
@@ -59,6 +54,10 @@ release/entrega-final-correcta
 - [feature/modelador-casos-uso] Integración de la vista previa de diagramas en `introduccion.md`.
 
 ### Fixed
+- Corregida sintaxis de enlace de NotebookLM grupal en introduccion.md (@keviineze - Modelador de Casos de Uso). 
+  PR: https://github.com/Purezaamor/SistemaTurnosMedicos/pull/30
+- Corregida los nombres de los actores en los Casos de Uso en introduccion.md (@keviineze - Modelador de Casos de Uso)
+  PR: https://github.com/Purezaamor/SistemaTurnosMedicos/pull/37
 - [fix/workflow-cleanup] Corrección del flujo de trabajo y revert de merges accidentales a master (@Purezaamor).
   PR: [#35] [https://github.com/Purezaamor/SistemaTurnosMedicos/pull/35]
 - [fix/templates-init] Incorporación de plantillas obligatorias para Issues y Pull Requests (@Purezaamor).


### PR DESCRIPTION
Se realiza la corrección de los nombres de los Actores como indica el profesor para que sea unos actores genéricos por si sucede alguna renuncia o hay un cambio de personal.