### PR TITLE
fix: corregir tag de imagen duplicado en introduccion.md (RC3)

### DIFF
--- a/anexos/introduccion.md
+++ b/anexos/introduccion.md
@@ -166,11 +166,6 @@ Se utilizó NotebookLM para analizar los requisitos del sistema.
 - **Turno**: Contiene `fecha`, `hora`, `estado`, y referencias a Paciente y Medico.
 
 ### Diagrama de Clases
-![Diagrama de Clases] ![Diagrama de Clases](./../../diagramas/01-diagrama-clases/01-boceto-inicial.png)
+![Diagrama de Clases](../diagramas/01-diagrama-clases/01-boceto-inicial.png)
 
 ---
-
-
-
-
-

--- a/changelog.md
+++ b/changelog.md
@@ -51,3 +51,5 @@
    PR: [#35] [https://github.com/Purezaamor/SistemaTurnosMedicos/pull/35]
 - Corrección de la ruta de visualización del diagrama de clases en `introduccion.md`, cambiando el puntero de `.excalidraw` a `.png` para permitir el renderizado en GitHub. [[PR #36](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/36)]
 - Corregidos artefactos de merge y limpieza de estructura en changelog.md.
+- Corregido error de renderizado (tag duplicado) en el Diagrama de Clases de introduccion.md. (@keviineze)
+  PR: https://github.com/Purezaamor/SistemaTurnosMedicos/pull/40


### PR DESCRIPTION
Corregido error de renderizado (tag duplicado) en el Diagrama de Clases de introduccion.md.