### PR TITLE
fix: corrige changelog (ubicación correcta + agrega PR faltantes y #86)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -68,6 +68,7 @@
 
 - [fix/correcciones finales (UML, CRC, changelog y limpieza)] Resolución de conflictos, limpieza de duplicados, corrección de índices y actualización final del changelog. PR: [#86](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/86)
 
+- [fix/correcciones finales adicionales] Ajustes finales sobre UML, conflictos y consistencia general del repositorio. PR: [#87](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/87)
 
 ---
 

--- a/changelog.md
+++ b/changelog.md
@@ -56,6 +56,18 @@
 
 - [fix/changelog-duplicados] Eliminación de líneas duplicadas en `changelog.md` para mantener consistencia y cumplimiento de formato en la entrega final de la Actividad Obligatoria N°2. PR: [#78](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/78) — @nachonervi-design (Documentador y Coordinador)
 
+- [fix/herramientas agile formato nueva] Corrección de formato en herramientas agile. PR: [#85](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/85)
+
+- [fix/modelador casos usoA2] Ajustes en tarjetas CRC y documentación. PR: [#84](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/84)
+
+- [fix/changelog final ajustes] Ajustes finales en changelog. PR: [#82](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/82)
+
+- [fix/herramientas agile formato] Corrección previa de herramientas agile. PR: [#76](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/76)
+
+- [feature/escenarios cu] Implementación de escenarios de casos de uso. PR: [#57](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/57)
+
+- [fix/correcciones finales (UML, CRC, changelog y limpieza)] Resolución de conflictos, limpieza de duplicados, corrección de índices y actualización final del changelog. PR: [#86](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/86)
+
 
 ---
 
@@ -90,13 +102,3 @@
 - [fix/notebooklm-link] Corrección de sintaxis del enlace de NotebookLM en `introduccion.md`. PR: [#30](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/30) — @keviineze (Modelador de Casos de Uso)
 
 - [fix/diagrama-tag] Corrección de error de renderizado (tag duplicado) en el diagrama de clases. PR: [#40](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/40) — @keviineze (Modelador de Casos de Uso)
-
-- [fix/herramientas agile formato nueva] Corrección de formato en herramientas agile. PR: [#85](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/85)
-
-- [fix/modelador casos usoA2] Ajustes en tarjetas CRC y documentación. PR: [#84](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/84)
-
-- [fix/changelog final ajustes] Ajustes finales en changelog. PR: [#82](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/82)
-
-- [fix/herramientas agile formato] Corrección previa de herramientas agile. PR: [#76](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/76)
-
-- [feature/escenarios cu] Implementación de escenarios de casos de uso. PR: [#57](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/57)

--- a/diagramas/diagramasUML.md
+++ b/diagramas/diagramasUML.md
@@ -1,4 +1,3 @@
 # Diagramas UML
 - [Diagramas de Casos de Uso](02-casos-de-uso/diagramas_de_casos_de_uso.md)
 - [Escenarios de Casos de Uso](03-escenarios-casos-de-uso/escenarios_de_casos_de_uso.md)
-


### PR DESCRIPTION
## Descripción

Se corrige el changelog según observaciones de revisión técnica.

## Cambios realizados

- Reubicación de PR en la sección correcta (Release Actividad Obligatoria N°2)
- Eliminación de PR mal ubicadas en Release Actividad Obligatoria N°1
- Incorporación de PR faltantes en la sección Fixed (#85, #84, #82, #76, #57)
- Autorreferencia de la PR actual (#86) en el changelog

## Resultado

Se garantiza la trazabilidad completa de cambios, cumpliendo con la convención del proyecto:
cada PR mergeada se encuentra documentada en el changelog dentro de la release correspondiente.