### PR TITLE
[Fix] Correcciones OCP/LSP según request changes

### DIFF
--- a/anexos/principios-solid/02-ocp.md
+++ b/anexos/principios-solid/02-ocp.md
@@ -1,39 +1,23 @@
 # Principio Abierto/Cerrado (OCP)
 
-## Propósito
+## Propósito y Tipo del Principio SOLID
 
-El principio Abierto/Cerrado establece que las entidades de software deben estar abiertas para su extensión, pero cerradas para su modificación.
+El principio Abierto/Cerrado (OCP) establece que las entidades de software (clases, módulos, funciones) deben estar **abiertas para su extensión**, pero **cerradas para su modificación**. Esto permite agregar nuevo comportamiento sin alterar el código existente que ya funciona.
 
 ## Motivación
 
-En el sistema de turnos médicos, la clase Turno inicialmente contenía lógica condicional para manejar distintos tipos de consultas (presencial, virtual, etc.). Este enfoque implicaba modificar la clase cada vez que se agregaba un nuevo tipo de turno.
+En el sistema de turnos médicos, originalmente la clase `Turno` contenía lógica condicional (if/switch) para determinar acciones según el tipo de consulta (general, especialista, urgencia). Cada vez que se quería agregar un nuevo tipo de consulta, había que modificar la clase `Turno`, violando OCP y aumentando el riesgo de introducir errores en funcionalidades ya probadas.
 
-Esto generaba un diseño rígido, difícil de mantener y propenso a errores.
+Aplicando OCP, creamos una abstracción `TipoConsulta` y movermos los comportamientos específicos a subclases (`ConsultaGeneral`, `ConsultaEspecialista`, `ConsultaUrgencia`). De esta forma, el sistema puede extenderse con nuevos tipos de consulta sin modificar la clase `Turno` ni las clases existentes.
 
-## Problema detectado
+## Explicación de Herencia
 
-Se identificó el uso de estructuras condicionales dentro de la clase Turno para determinar comportamientos según el tipo de consulta.
+La herencia es un mecanismo de la programación orientada a objetos que permite que una clase (subclase) herede atributos y métodos de otra clase (superclase). Para cumplir con OCP, utilizamos una **clase abstracta** o **interfaz** como contrato base, y las subclases concretas implementan comportamientos específicos. La clase que usa estas abstracciones (como `Turno`) depende de la abstracción, no de las implementaciones concretas, permitiendo agregar nuevas subclases sin modificar el código cliente.
 
-Cada nuevo tipo de turno requería modificar el código existente, violando el principio OCP.
+## Estructura de Clases
 
-## Solución aplicada
+![Diagrama UML - OCP](../../diagramas/01-diagrama-clases/01-solid-02-ocp.png)
 
-Se redefinió la clase Turno como abstracta y se crearon subclases específicas:
+## Justificación Técnica
 
-* TurnoPresencial
-* TurnoVirtual
-* TurnoDomicilio
-
-Cada subclase implementa su comportamiento particular, permitiendo extender el sistema sin modificar la clase base.
-
-## Diagrama UML
-
-Ver archivo:
-
-diagramas/01-diagrama-clases/01-solid-02-ocp.png
-
-## Justificación técnica
-
-La solución elimina la necesidad de modificar la clase Turno ante nuevos requerimientos, delegando la variabilidad a nuevas subclases.
-
-Esto reduce el acoplamiento, mejora la mantenibilidad y permite escalar el sistema de manera controlada, cumpliendo correctamente con el principio OCP.
+En el diagrama se observa que la clase `Turno` mantiene una referencia a la abstracción `TipoConsulta` (una interfaz o clase abstracta). Las clases concretas `ConsultaGeneral`, `ConsultaEspecialista` y `ConsultaUrgencia` implementan esta abstracción, cada una con su propia lógica de duración, preparación o prioridad. De esta manera, `Turno` no necesita saber qué tipo concreto de consulta está manejando; solo invoca los métodos definidos en la abstracción. Si en el futuro se requiere un nuevo tipo de consulta (ej. `ConsultaTelemedicina`), basta con crear una nueva subclase sin tocar `Turno` ni las otras consultas, cumpliendo con OCP.

--- a/anexos/principios-solid/03-lsp.md
+++ b/anexos/principios-solid/03-lsp.md
@@ -1,39 +1,29 @@
 # Principio de Sustitución de Liskov (LSP)
 
-## Propósito
+## Propósito y Tipo del Principio SOLID
 
-El principio de Sustitución de Liskov establece que los objetos de una subclase deben poder reemplazar a los objetos de su clase base sin alterar el comportamiento esperado del sistema.
+El principio de Sustitución de Liskov (LSP) establece que si S es un subtipo de T, entonces los objetos de tipo T pueden ser reemplazados por objetos de tipo S sin alterar el comportamiento correcto del programa. En otras palabras, las subclases deben poder sustituir a sus superclases sin que el sistema falle o se comporte de manera inesperada.
 
 ## Motivación
 
-El sistema de turnos médicos presenta una jerarquía de clases basada en Persona, de la cual derivan Paciente, Medico y Secretaria.
+En el sistema de turnos médicos, inicialmente se planteó una jerarquía donde `Persona` era la superclase, y `Paciente` y `Medico` eran subclases. Sin embargo, surgió un problema: se asignaron responsabilidades a `Paciente` (como `asignarTurno()`) que no tenían sentido para `Medico`, y viceversa (método `recetar()` en `Medico` que no aplicaba a `Paciente`). Esto violaba LSP porque una instancia de `Paciente` no podía reemplazar a `Persona` sin romper el comportamiento esperado.
 
-Es necesario garantizar que estas subclases respeten el comportamiento definido en la clase base.
+La solución fue rediseñar la jerarquía: `Persona` solo contiene atributos comunes (nombre, DNI, contacto). Los comportamientos específicos se mueven a interfaces segregadas (`IPuedeAsignarTurno`, `IPuedeRecetar`). Las subclases implementan solo las interfaces que necesitan, garantizando que cualquier instancia de `Paciente` puede reemplazar a `Persona` sin problemas.
 
-## Problema detectado
+## Explicación de Herencia
 
-Un diseño incorrecto podría llevar a que las subclases modifiquen o eliminen comportamientos esenciales, generando inconsistencias y errores en el sistema.
+La herencia permite que una subclase herede y extienda el comportamiento de una superclase. Para respetar LSP, la subclase no debe:
+- Reforzar precondiciones
+- Debilitar poscondiciones
+- Lanzar excepciones nuevas que la superclase no lance
+- Modificar el estado de manera que el supertipo no espere
 
-## Solución aplicada
+En nuestro diseño, `Paciente` y `Medico` heredan solo atributos y métodos comunes de `Persona` (getters, setters básicos). Cualquier comportamiento adicional se define en interfaces separadas, garantizando que la sustitución sea segura.
 
-Se definió una jerarquía coherente:
+## Estructura de Clases
 
-Persona
+![Diagrama UML - LSP](../../diagramas/01-diagrama-clases/01-solid-03-lsp.png)
 
-* Paciente
-* Medico
-* Secretaria
+## Justificación Técnica
 
-Todas las subclases mantienen los atributos y comportamientos definidos en Persona, extendiendo funcionalidad sin alterar su contrato.
-
-## Diagrama UML
-
-Ver archivo:
-
-diagramas/01-diagrama-clases/01-solid-03-lsp.png
-
-## Justificación técnica
-
-Las subclases pueden utilizarse como instancias de Persona sin generar efectos inesperados.
-
-Esto asegura coherencia en el diseño, favorece la reutilización de código y garantiza el cumplimiento del principio LSP.
+En el diagrama se observa que `Persona` es una clase base con atributos comunes. `Paciente` y `Medico` heredan de `Persona` sin sobrescribir métodos de manera conflictiva. Además, se aplica el principio de segregación de interfaces (ISP) en conjunto: `Paciente` implementa `IPuedeAsignarTurno` y `IPuedeCancelarTurno`, mientras que `Medico` implementa `IPuedeRecetar` y `IPuedeVerAgenda`. Cualquier función que reciba un parámetro de tipo `Persona` puede recibir tanto un `Paciente` como un `Medico` sin romper el comportamiento esperado, cumpliendo así con LSP.

--- a/anexos/principios-solid/principios_solid.md
+++ b/anexos/principios-solid/principios_solid.md
@@ -6,4 +6,4 @@ Los Principios SOLID son un conjunto de buenas prácticas dentro del Diseño Ori
 - [Abierto/Cerrado (OCP)](/anexos/principios-solid/02-ocp.md)
 - [Sustitucion de Liskov (LSP)](/anexos/principios-solid/03-lsp.md)
 - [Segregación de Interfaces (ISP)](/anexos/principios-solid/04-isp.md)
-- [Inversion de Dependencias](/anexos/principios-solid/05-dip.md)
+- [Inversión de Dependencias (DIP)](/anexos/principios-solid/05-dip.md)

--- a/changelog.md
+++ b/changelog.md
@@ -1,109 +1,80 @@
 # Changelog
 
-## [Release Primer Parcial] - 2026-05-04
+## [Unreleased]
+
+---
+
+## [Release Actividad Obligatoria N°2] - 2026-04-17
 
 ### Added
 
-- [feature/esp-isp-add-anexo-isp] Análisis de Principio ISP y diseño de diagrama UML para Segregación de Interfaces. PR: [#92](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/92) - @keviineze (Especialista en Segregación de Interfaces).
+- [feature/modelador-diag-casos-uso] Modelado de 5 diagramas de casos de uso en PlantUML y exportación a PNG. PR: [#20](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/20) — @keviineze (Modelador de Casos de Uso)
 
-- [feature/esp-extension-ocp-lsp] Aplicación de principios OCP y LSP en el sistema de turnos médicos. PR: #91 — @Purezaamor (Alejo Guerricabeitia)
+- [feature/a2-tarjetas-crc] Creación de tarjetas CRC en archivos individuales, incluyendo responsabilidades, colaboradores y pensamiento del objeto. PR: [#51](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/51) — @Purezaamor (Diseñador de Tarjetas CRC)
 
-- Refactor de la clase Turno aplicando OCP:
-  - TurnoPresencial
-  - TurnoVirtual
-  - TurnoDomicilio
+- [feature/doc-coord-repo-update-readme-md-a2] Actualización de README.md con estructura final del proyecto, índices de navegación y documentación del equipo. PR: [#52](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/52) — @nachonervi-design (Documentador y Coordinador)
 
-- Aplicación de LSP en la jerarquía Persona:
-  - Paciente
-  - Medico
-  - Secretaria
-
-- Diseño y creación de diagramas UML:
-  - 01-solid-02-ocp.puml / .png
-  - 01-solid-03-lsp.puml / .png
-
-- Documentación de IA:
-  - ia/primer-parcial/especialista-ocp.md
-  - ia/primer-parcial/especialista-lsp.md
-
-- Documentación de diseño:
-  - anexos/principios-solid/02-ocp.md
-  - anexos/principios-solid/03-lsp.md
-
----
+- [feature/esp-extension-ocp-lsp] Aplicación de principios OCP y LSP en el sistema de turnos médicos. PR: [#91](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/91) — @Purezaamor (Especialista en Principios de Extensión)
 
 ### Changed
 
-- Ajuste del modelo de dominio para cumplir OCP (eliminación de lógica condicional en Turno)
-- Reorganización de jerarquías para asegurar LSP en Persona
-- Integración del diseño con el sistema de turnos existente (Agenda y Turno)
+- [feature/escenarios-cu] Reestructuración completa de escenarios de casos de uso en carpeta dedicada, con archivos individuales e índice central. PR: [#50](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/50) — @Purezaamor (Especialista en Escenarios)
+
+### Fixed
+
+- [fix/ia-y-herramientas-agile] Corrección de formato en prompts de IA (triple backtick) y limpieza del archivo herramientas_agile.md. PR: [#73](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/73) — @nachonervi-design (Documentador y Coordinador)
+
+- [fix/diagramas-links-subindices] Corrección de enlaces en diagramas UML: actualización de rutas para apuntar a sub-índices (.md) en lugar de carpetas. PR: [#74](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/74) — @nachonervi-design (Documentador y Coordinador)
+
+- [fix/escenarios-links-formato] Corrección de formato en enlaces de escenarios de casos de uso: actualización al formato completo CU-N - Nombre - Escenario. PR: [#75](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/75) — @nachonervi-design (Documentador y Coordinador)
+
+- [fix/changelog-readme] Corrección final de `changelog.md` y `README.md` según observaciones de revisión. PR: [#59](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/59) — @nachonervi-design (Documentador y Coordinador)
+
+- [fix/especialista-escenarios-casos-uso-a2] Corrección de escenarios: naming, flujo de cancelación y actualización del índice. PR: [#61](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/61) — @Purezaamor (Especialista en Escenarios)
+
+- [fix/correcciones-modelador-diagramas-a2] Corrección de diagramas de casos de uso: ajuste de sintaxis UML, relaciones <<include>> y actualización de PNG e índice. PR: [#62](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/62) — @keviineze (Modelador de Casos de Uso)
+
+- [fix/diseniador-tarjetas-crc-a2] Corrección de tarjetas CRC: incorporación de clases Secretaria y LlegadaPaciente, ajuste de la tarjeta Turno (tipoConsulta y estados) y mejora de Agenda e índices de herramientas agile. PR: [#60](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/60) — @Purezaamor (Diseñador de Tarjetas CRC)
+
+- [fix/backport-modelador-a2] Corrección de diagrama cancelar-turno (<<include>>), actualización de índice diagramasUML.md y documentación IA modelador. PR: [#66](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/66) — @keviineze (Modelador de Casos de Uso)
+
+- [fix/changelog-a1-formato-final] Corrección del formato en la sección de la Actividad Obligatoria N°1: normalización de entradas en `### Changed` y `### Fixed` según Keep a Changelog (PR links, autores y estructura). PR: [#68](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/68) — @nachonervi-design (Documentador y Coordinador)
+
+- [fix/herramientas-agile-formato] Aplicación de correcciones finales de revisión: normalización de `herramientas_agile.md`, corrección del índice en `tarjetas_crc.md` y mejora de la documentación de IA (CRC y escenarios: prompts, contexto, iteraciones y outputs). PR: [#67](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/67) — @nachonervi-design (Documentador y Coordinador)
+
+- [fix/ia-documentador-prompts] Corrección de formato en documentación de IA: se envuelven los prompts en bloques de código triple backtick en `ia/a2/documentador-coordinador.md`. PR: [#71](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/71) — @nachonervi-design (Documentador y Coordinador)
+
+- [fix/limpieza-changelog-a2] Corrección de `changelog.md` según observaciones de revisión. PR: [#70](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/70) — @keviineze (Modelador de Casos de Uso)
+
+- [fix/prompts-ia-y-changelog-final] Corrección final de formato en documentación de IA: prompts envueltos en bloques de código triple backtick en archivos de CRC, escenarios y documentador; ajuste de entradas faltantes e incorrectas en `changelog.md`. PR: [#72](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/72) — @nachonervi-design (Documentador y Coordinador)
+
+- [fix/correcciones-finales-rc] Aplicación de correcciones finales de revisión (RC): ajustes en herramientas_agile, tarjetas CRC (Turno y herencia), escenarios de casos de uso, enlaces de diagramas UML y documentación de IA. PR: [#69](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/69) — @nachonervi-design (Documentador y Coordinador)
+
+- [fix/modelador-casos-uso-crc] Corrección y refactorización del modelo de tarjetas CRC: unificación de atributos en Persona, redistribución de responsabilidades, incorporación de HistorialCambios y alineación con requisitos funcionales. PR: [#80](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/80) — @keviineze (Modelador de Casos de Uso)
+
+- [fix/changelog-duplicados] Eliminación de líneas duplicadas en `changelog.md` para mantener consistencia y cumplimiento de formato en la entrega final de la Actividad Obligatoria N°2. PR: [#78](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/78) — @nachonervi-design (Documentador y Coordinador)
+
+- [fix/herramientas agile formato nueva] Corrección de formato en herramientas agile. PR: [#85](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/85)
+
+- [fix/modelador casos usoA2] Ajustes en tarjetas CRC y documentación. PR: [#84](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/84)
+
+- [fix/changelog final ajustes] Ajustes finales en changelog. PR: [#82](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/82)
+
+- [fix/herramientas agile formato] Corrección previa de herramientas agile. PR: [#76](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/76)
+
+- [feature/escenarios cu] Implementación de escenarios de casos de uso. PR: [#57](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/57)
+
+- [fix/correcciones finales (UML, CRC, changelog y limpieza)] Resolución de conflictos, limpieza de duplicados, corrección de índices y actualización final del changelog. PR: [#86](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/86)
+
+- [fix/correcciones finales adicionales] Ajustes finales sobre UML, conflictos y consistencia general del repositorio. PR: [#87](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/87)
 
 ---
 
-### Result
+## [Release Actividad Obligatoria N°1] - 2026-03-25
 
-El sistema ahora permite extender tipos de turnos sin modificar la clase base y garantiza sustitución correcta entre subclases de Persona, cumpliendo principios SOLID.
+### Added
 
-[Release Actividad Obligatoria N°2] - 2026-04-17
-Added
-[feature/modelador-diag-casos-uso] Modelado de 5 diagramas de casos de uso en PlantUML y exportación a PNG. PR: #20 — @keviineze (Modelador de Casos de Uso)
-
-[feature/a2-tarjetas-crc] Creación de tarjetas CRC en archivos individuales, incluyendo responsabilidades, colaboradores y pensamiento del objeto. PR: #51 — @Purezaamor (Diseñador de Tarjetas CRC)
-
-[feature/doc-coord-repo-update-readme-md-a2] Actualización de README.md con estructura final del proyecto, índices de navegación y documentación del equipo. PR: #52 — @nachonervi-design (Documentador y Coordinador)
-
-Changed
-[feature/escenarios-cu] Reestructuración completa de escenarios de casos de uso en carpeta dedicada, con archivos individuales e índice central. PR: #50 — @Purezaamor (Especialista en Escenarios)
-Fixed
-[fix/ia-y-herramientas-agile] Corrección de formato en prompts de IA (triple backtick) y limpieza del archivo herramientas_agile.md. PR: #73 — @nachonervi-design (Documentador y Coordinador)
-
-[fix/diagramas-links-subindices] Corrección de enlaces en diagramas UML: actualización de rutas para apuntar a sub-índices (.md) en lugar de carpetas. PR: #74 — @nachonervi-design (Documentador y Coordinador)
-
-[fix/escenarios-links-formato] Corrección de formato en enlaces de escenarios de casos de uso: actualización al formato completo CU-N - Nombre - Escenario. PR: #75 — @nachonervi-design (Documentador y Coordinador)
-
-[fix/changelog-readme] Corrección final de changelog.md y README.md según observaciones de revisión. PR: #59 — @nachonervi-design (Documentador y Coordinador)
-
-[fix/especialista-escenarios-casos-uso-a2] Corrección de escenarios: naming, flujo de cancelación y actualización del índice. PR: #61 — @Purezaamor (Especialista en Escenarios)
-
-[fix/correcciones-modelador-diagramas-a2] Corrección de diagramas de casos de uso: ajuste de sintaxis UML, relaciones <> y actualización de PNG e índice. PR: #62 — @keviineze (Modelador de Casos de Uso)
-
-[fix/diseniador-tarjetas-crc-a2] Corrección de tarjetas CRC: incorporación de clases Secretaria y LlegadaPaciente, ajuste de la tarjeta Turno (tipoConsulta y estados) y mejora de Agenda e índices de herramientas agile. PR: #60 — @Purezaamor (Diseñador de Tarjetas CRC)
-
-[fix/backport-modelador-a2] Corrección de diagrama cancelar-turno (<>), actualización de índice diagramasUML.md y documentación IA modelador. PR: #66 — @keviineze (Modelador de Casos de Uso)
-
-[fix/changelog-a1-formato-final] Corrección del formato en la sección de la Actividad Obligatoria N°1: normalización de entradas en ### Changed y ### Fixed según Keep a Changelog (PR links, autores y estructura). PR: #68 — @nachonervi-design (Documentador y Coordinador)
-
-[fix/herramientas-agile-formato] Aplicación de correcciones finales de revisión: normalización de herramientas_agile.md, corrección del índice en tarjetas_crc.md y mejora de la documentación de IA (CRC y escenarios: prompts, contexto, iteraciones y outputs). PR: #67 — @nachonervi-design (Documentador y Coordinador)
-
-[fix/ia-documentador-prompts] Corrección de formato en documentación de IA: se envuelven los prompts en bloques de código triple backtick en ia/a2/documentador-coordinador.md. PR: #71 — @nachonervi-design (Documentador y Coordinador)
-
-[fix/limpieza-changelog-a2] Corrección de changelog.md según observaciones de revisión. PR: #70 — @keviineze (Modelador de Casos de Uso)
-
-[fix/prompts-ia-y-changelog-final] Corrección final de formato en documentación de IA: prompts envueltos en bloques de código triple backtick en archivos de CRC, escenarios y documentador; ajuste de entradas faltantes e incorrectas en changelog.md. PR: #72 — @nachonervi-design (Documentador y Coordinador)
-
-[fix/correcciones-finales-rc] Aplicación de correcciones finales de revisión (RC): ajustes en herramientas_agile, tarjetas CRC (Turno y herencia), escenarios de casos de uso, enlaces de diagramas UML y documentación de IA. PR: #69 — @nachonervi-design (Documentador y Coordinador)
-
-[fix/modelador-casos-uso-crc] Corrección y refactorización del modelo de tarjetas CRC: unificación de atributos en Persona, redistribución de responsabilidades, incorporación de HistorialCambios y alineación con requisitos funcionales. PR: #80 — @keviineze (Modelador de Casos de Uso)
-
-[fix/changelog-duplicados] Eliminación de líneas duplicadas en changelog.md para mantener consistencia y cumplimiento de formato en la entrega final de la Actividad Obligatoria N°2. PR: #78 — @nachonervi-design (Documentador y Coordinador)
-
-[fix/herramientas agile formato nueva] Corrección de formato en herramientas agile. PR: #85
-
-[fix/modelador casos usoA2] Ajustes en tarjetas CRC y documentación. PR: #84
-
-[fix/changelog final ajustes] Ajustes finales en changelog. PR: #82
-
-[fix/herramientas agile formato] Corrección previa de herramientas agile. PR: #76
-
-[feature/escenarios cu] Implementación de escenarios de casos de uso. PR: #57
-
-[fix/correcciones finales (UML, CRC, changelog y limpieza)] Resolución de conflictos, limpieza de duplicados, corrección de índices y actualización final del changelog. PR: #86
-
-[fix/correcciones finales adicionales] Ajustes finales sobre UML, conflictos y consistencia general del repositorio. PR: #87
-
-[Release Actividad Obligatoria N°1] - 2026-03-25
-Added
-[feature/analista-requerimientos] Normalización de 5 RF y 5 RNF; definición de alcance MVP; enlace a NotebookLM. PR: #8 — @nachonervi-design (Analista de Requerimientos)
+- [feature/analista-requerimientos] Normalización de 5 RF y 5 RNF; definición de alcance MVP; enlace a NotebookLM. PR: [#8](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/8) — @nachonervi-design (Analista de Requerimientos)
 
 - [feature/disenio-clases] Creación del diagrama de clases inicial en Excalidraw y exportación a PNG. PR: [#7](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/7) — @lucastol-dev (Diseñador de Clases)
 
@@ -111,15 +82,11 @@ Added
 
 - [feature/doc-coord-repo] Creación de estructura de carpetas, README institucional y anexos. PR: [#10](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/10) — @Purezaamor (Documentador y Coordinador)
 
----
-
 ### Changed
 
 - [feature/doc-coord-repo] Actualización de la carátula con datos completos de los integrantes en `README.md`. PR: [#36](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/36) — @Purezaamor (Documentador y Coordinador)
 
 - [feature/modelador-casos-uso] Integración de la vista previa de diagramas en `introduccion.md`. PR: [#37](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/37) — @keviineze (Modelador de Casos de Uso)
-
----
 
 ### Fixed
 
@@ -129,4 +96,4 @@ Added
 
 - [fix/notebooklm-link] Corrección de sintaxis del enlace de NotebookLM en `introduccion.md`. PR: [#30](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/30) — @keviineze (Modelador de Casos de Uso)
 
-[fix/diagrama-tag] Corrección de error de renderizado (tag duplicado) en el diagrama de clases. PR: #40 — @keviineze (Modelador de Casos de Uso)
+- [fix/diagrama-tag] Corrección de error de renderizado (tag duplicado) en el diagrama de clases. PR: [#40](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/40) — @keviineze (Modelador de Casos de Uso)


### PR DESCRIPTION
## Correcciones realizadas

- RC9: Agregado `(DIP)` en principios_solid.md
- RC2, RC4: Formato corregido en 02-ocp.md y 03-lsp.md (5 secciones exactas)
- RC3, RC5: Corregida incrustación de imágenes
- RC16, RC17: Limpieza de changelog.md