### PR TITLE
fix(arquitecto-dominio): corregir error en diagrama link caido en A4

### DIFF
--- a/anexos/analisis-funcional/05-caso-de-uso-administrar-disponibilidad.md
+++ b/anexos/analisis-funcional/05-caso-de-uso-administrar-disponibilidad.md
@@ -59,7 +59,7 @@
 
 ## Diagrama de secuencia (A3)
 
-![Diagrama de secuencia - Administrar Disponibilidad](../../diagramas/05-diagramas-secuencia/05-secuencia-administrar-disponibilidad-flujo-principal-04.png)
+![Diagrama de secuencia - Administrar Disponibilidad](../../diagramas/05-diagramas-secuencia/05-secuencia-autorizar-sobreturno-flujo-principal-04.png)
 
 ### Participantes y mensajes clave
 

--- a/changelog.md
+++ b/changelog.md
@@ -13,11 +13,14 @@
 - [fix/analista-funcional-caso-1] Se corrigen las entradas de IDs. PR: [#177](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/177) - @sofinestt (Analista Funcional de Casos de Uso 2 y 3)
 
 - [fix/analista-fun-casos-2-3] Incorporación de nuevas tarjetas CRC, actualización de casos de uso y diagrama de clases, y corrección de referencias entre artefactos. PR:[#172](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/172)- @sofinestt (Analista Funcional de Casos de Uso 2 y 3)
+
 - [fix/arquitecto-dominio-correcciones-a4] Correcciones de RC32 a RC35 modificando los archivos `analisis_casos_uso.md`, `happy-path-global.md` y `anexos.md`. PR:[#173](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/173) - @keviineze (Arquitecto de Dominio).
 
 - [fix/analista-funcional-2-fix] Se agregan tarjetas CRC faltantes para consistencia de codigo y se corrige pseudocodigo. PR:[#179](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/179)- @sofinestt (Analista Funcional de Casos de Uso 2 y 3)
 
 - [fix/analista-fun-casos-1-2-3-fix] Se corrige plantilla en tarjeta CRC persona y se corrije pseudocódigo. PR: [#180](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/180) - @sofinestt (Analista Funcional de Casos de Uso 2 y 3)
+
+- [fix/arquitecto-dominio-correcciones-a4-2] Correcciones de RCN4 modificando el link del diagrama en `anexos/analisis-funcional/05-caso-de-uso-administrar-disponibilidad.md`. PR:[#181](https://github.com/Purezaamor/SistemaTurnosMedicos/pull/181) - @keviineze (Arquitecto de Dominio).
 
 ## [Release Actividad Obligatoria N°3] - 2026-05-07
 


### PR DESCRIPTION
Se corrigió el link de enlace del diagrama el cual estaba mal. Pedido por "RCN4".